### PR TITLE
Updated Core Team URL

### DIFF
--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -29,7 +29,7 @@
     <p class="copyright pull-left">&copy; 2014-<span id="copyright-year">{{year}}</span> <a href="http://lucaguidi.com/">Luca Guidi</a> – Lotus is released under the MIT License.
     <br>
     <br> This website and its contents are released under <a href="http://creativecommons.org/licenses/by-nc/4.0/" href="_blank">CC Attribution-NonCommercial 4.0</a>.
-    <br> Maintained with <3 by the <a href="https://github.com/orgs/lotus/teams/core-team" target="_blank">core team</a> with help from <a href="https://github.com/lotus/lotus/graphs/contributors" target="_blank">contributors</a>. Site Design by <a href="http://www.alantippins.com/">Alan Tippins</a>.</p>
+    <br> Maintained with <3 by the <a href="https://github.com/orgs/lotus/people" target="_blank">core team</a> with help from <a href="https://github.com/lotus/lotus/graphs/contributors" target="_blank">contributors</a>. Site Design by <a href="http://www.alantippins.com/">Alan Tippins</a>.</p>
     <ul class="social">
       <li><a href="https://twitter.com/lotus_rb" target="_blank" class="icon-twitter"></a></li>
       <li><a href="https://github.com/lotus" target="_blank" class="icon-github"></a></li>


### PR DESCRIPTION
The current URL seems either dead or the page is private.