### PR TITLE
Remove view partials from navigation and fix link to database cmd line tools

### DIFF
--- a/source/guides/migrations/overview.md
+++ b/source/guides/migrations/overview.md
@@ -5,7 +5,7 @@ title: Lotus - Guides - Migrations
 # Migrations
 
 Migrations are a feature that allows to manage database schema via Ruby.
-They come with some [command line facilities](/guides/command-line/database] that allow to perform database operations or to [generate](/guides/command-line/generators) migrations.
+They come with some [command line facilities](/guides/command-line/database) that allow to perform database operations or to [generate](/guides/command-line/generators) migrations.
 
 Migrations are only avaliable if our application uses the [SQL adapter](/guides/models/overview).
 

--- a/source/layouts/guides.erb
+++ b/source/layouts/guides.erb
@@ -73,7 +73,6 @@
                   <li><a href="/guides/views/overview">Overview</a></li>
                   <li><a href="/guides/views/basic-usage">Basic Usage</a></li>
                   <li><a href="/guides/views/templates">Templates</a></li>
-                  <li><a href="/guides/views/partials">Partials</a></li>
                   <li><a href="/guides/views/mime-types">MIME Types</a></li>
                   <li><a href="/guides/views/layouts">Layouts</a></li>
                   <li><a href="/guides/views/custom-error-pages">Custom Error Pages</a></li>


### PR DESCRIPTION
1. I removed the link to the view partials guide, as it does not seem to exist. Correct me if i'm wrong :)
2. Fixed a link to the database command line guide in the Migration Overview article