### PR TITLE
Fix null-constraint violation exception in getting started guides

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -407,8 +407,6 @@ Lotus::Model.migration do
       primary_key :id
       column :title,      String,   null: false
       column :author,     String,   null: false
-      column :created_at, DateTime, null: false
-      column :updated_at, DateTime, null: false
     end
   end
 end


### PR DESCRIPTION
books table migration adds two columns (created_at, updated_at) which
have a null-constraint. To be able to persist `Book` objects we have
to add `created_at` and `updated_at` to `Book` entity attributes and
map them accordingly.