### PR TITLE
Fix Typo?

### DIFF
--- a/source/guides/index.md
+++ b/source/guides/index.md
@@ -36,7 +36,7 @@ Views are separated from templates so the logic inside can be well-contained and
 ### Lotus is Threadsafe
 
 Making use of threads is a great way to boost the performance of your
-application. It shouldn't be hard to write thread-safe code, and Lotus (when
+application. It shouldn't be hard to write thread-safe code, and Lotus (whether
 the entire framework, or parts of it) is runtime threadsafe.
 
 ## Guides


### PR DESCRIPTION
Was reading through the docs and wasn't sure if this line had a typo, specifically:

"...and Lotus (when the entire framework, or parts of it) is runtime threadsafe."

Added an alternative - but no worries if the original is preferred!