### PR TITLE
FIXED: Correct use for session on controller

### DIFF
--- a/source/guides/actions/sessions.md
+++ b/source/guides/actions/sessions.md
@@ -51,9 +51,9 @@ module Web::Controllers::Dashboard
     include Web::Action
 
     def call(params)
-      sessions[:b]         # read
-      sessions[:a] = 'foo' # assign
-      sessions[:c] = nil   # remove
+      session[:b]         # read
+      session[:a] = 'foo' # assign
+      session[:c] = nil   # remove
     end
   end
 end


### PR DESCRIPTION
# Before

```ruby
# apps/web/controllers/dashboard/index.rb
module Web::Controllers::Dashboard
  class Index
    include Web::Action

    def call(params)
      sessions[:b]         # read
      sessions[:a] = 'foo' # assign
      sessions[:c] = nil   # remove
    end
  end
end
```

# After

```ruby
# apps/web/controllers/dashboard/index.rb
module Web::Controllers::Dashboard
  class Index
    include Web::Action

    def call(params)
      session[:b]         # read
      session[:a] = 'foo' # assign
      session[:c] = nil   # remove
    end
  end
end
```