### PR TITLE
Update getting-started.md

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -756,10 +756,11 @@ module Web::Controllers::Books
   class Create
     include Web::Action
 
-    def call(params)
-      book = Book.new(params[:book])
-      BookRepository.create(book)
+    expose :book
 
+    def call(params)
+      @book = BookRepository.create(Book.new(params[:book]))
+      
       redirect_to '/books'
     end
   end


### PR DESCRIPTION
Without exposing the variable `book`, the spec `spec/web/controllers/books/create_spec.rb` fails.

```
NoMethodError:         NoMethodError: undefined method 'book' for #<Web::Controllers::Books::Create:0x007ff5e5afbe40>
```

After I applies the changes of the PR the test passed. Am I missing something?