### PR TITLE
Change to proper redirect

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -981,7 +981,7 @@ We can use the `routes` helper method that is available in our views and actions
 We can make a similar change in `apps/controllers/books/create.rb`:
 
 ```ruby
-redirect_to routes.books_url
+redirect_to routes.books_path
 ```
 
 ## Wrapping Up


### PR DESCRIPTION
In the example first `redirect_to '/books'` is used.

Then after knowing the routes helper it is replaced with `redirect_to routes.books_url`.

This should be `redirect_to routes.books_path`