### PR TITLE
Fixes 'Displaying Validation Errors' spec example in the Getting Started Guide

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -761,7 +761,7 @@ module Web::Controllers::Books
 
     def call(params)
       @book = BookRepository.create(Book.new(params[:book]))
-      
+
       redirect_to '/books'
     end
   end
@@ -888,17 +888,26 @@ First, we expect a list of errors to be included in the page when `params` conta
 require 'spec_helper'
 require_relative '../../../../apps/web/views/books/new'
 
-let(:params)    { Lotus::Action::Params.new({}) }
-let(:exposures) { Hash[params: params] }
-let(:template)  { Lotus::View::Template.new('apps/web/templates/books/index.html.erb') }
-let(:view)      { Web::Views::Books::New.new(template, exposures) }
-let(:rendered)  { view.render }
+class NewBookParams < Lotus::Action::Params
+  param :book do
+    param :title, presence: true
+    param :author, presence: true
+  end
+end
 
-it 'displays list of errors when params contains errors' do
-  params.valid? # trigger validations
+describe Web::Views::Books::New do
+  let(:params)    { NewBookParams.new({}) }
+  let(:exposures) { Hash[params: params] }
+  let(:template)  { Lotus::View::Template.new('apps/web/templates/books/new.html.erb') }
+  let(:view)      { Web::Views::Books::New.new(template, exposures) }
+  let(:rendered)  { view.render }
 
-  rendered.must_include('There was a problem with your submission')
-  rendered.must_include('title is required')
+  it 'displays list of errors when params contains errors' do
+    params.valid? # trigger validations
+
+    rendered.must_include('There was a problem with your submission')
+    rendered.must_include('title is required')
+  end
 end
 ```
 


### PR DESCRIPTION
- Adds describe block 
- Fix to reference `new.html.erb` template instead of `index.html.erb` 
- Adds `NewBookParams` class to example to stub out validation rules, and uses an instance of that instead of base ` Lotus::Action::Params`, which contains no validation rules.

Unsure if this is the blessed way of making this test pass, so this is my best guess.   