### PR TITLE
Fix typo in application layout filename

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -277,7 +277,7 @@ Let's fix that.
 ### Layouts
 
 To avoid repeating ourselves in every single template, we can use a layout.
-Open up the file `apps/web/templates/application.htm.erb` and edit it to look like this:
+Open up the file `apps/web/templates/application.html.erb` and edit it to look like this:
 
 ```rhtml
 <!doctype HTML>


### PR DESCRIPTION
When we generate an app with `lotus new` we create `:name/apps/web/templates/application.html.erb`. The guide then refers to `application.htm.erb`, which I think is a typo. :grinning: