### PR TITLE
Fix let declaration in Getting Started guide

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -789,12 +789,13 @@ require 'spec_helper'
 require_relative '../../../../apps/web/controllers/books/create'
 
 describe Web::Controllers::Books::Create do
+  let(:action) { Web::Controllers::Books::Create.new }
+
   after do
     BookRepository.clear
   end
 
   describe 'with valid params' do
-    let(:action) { Web::Controllers::Books::Create.new }
     let(:params) { Hash[book: { title: '1984', author: 'George Orwell' }] }
 
     it 'creates a new book' do


### PR DESCRIPTION
The 'with invalid params' scenario should have access to the action
variable.