### PR TITLE
use correct instance variables from let

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -551,7 +551,7 @@ describe Web::Views::Books::Index do
     end
 
     it 'hides the placeholder message' do
-      view.render.wont_include('<p class="placeholder">There are no books yet.</p>')
+      rendered.wont_include('<p class="placeholder">There are no books yet.</p>')
     end
   end
 end


### PR DESCRIPTION
since you have already defined  `let(:rendered)  { view.render }` , there is no reason to use `view.render` again