### PR TITLE
Add adapter if not using postgres

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -398,6 +398,8 @@ The placeholders **_user_** and **_password_** should be replaced with the corre
 
 You may want to change `localhost` for `127.0.0.1` if you're using Linux.
 
+You may decide to use a different adapter, if you do make sure that you update your Gemfile to include the adapter of your choice and run bundle install.
+
 The database configured by default, called `bookshelf_development` running on `localhost`, should work fine for now.
 Lotus can create the database for us:
 
@@ -847,7 +849,7 @@ With our validations in place, we can limit our entity creation and redirection 
 module Web::Controllers::Books
   class Create
     include Web::Action
-    
+
     expose :book
 
     params do


### PR DESCRIPTION
If the user decides to use a different adapter to `postgres` they will be thrown an error. This is also the case if the user sets up a new project without specifying an adapter.

In order to stop this happening, the adapter of their choice needs to be specified in the Gemfile, I have simply added a line to the get started documentation to outline this if the user decides to choose a different adapter they will need to add this to the Gemfile.