### PR TITLE
Update guides to mention generated actions using RESTful HTTP methods

### DIFF
--- a/source/guides/command-line/generators.md
+++ b/source/guides/command-line/generators.md
@@ -67,6 +67,16 @@ This will generate the following route:
 get '/books/:id', to: 'books#show'
 ```
 
+The default HTTP method is `GET`, except for actions named:
+
+- `create`, which will use `POST`
+- `update`, which will use `PATCH`
+- `destroy`, which will use `DELETE`
+
+This should help you route using [RESTful resources](/guides/routing/restful-resources).
+
+You can also set the HTTP method by specifying a `--method` argument when calling `lotus generate action`.
+
 ### Models
 
 We can generate a model.

--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -719,7 +719,7 @@ Let's create a `Books::Create` action:
 % lotus generate action web books#create
 ```
 
-Let's change the HTTP method that our route will accept (`POST`).
+This adds a new route to our app:
 
 ```ruby
 # apps/web/config/routes.rb


### PR DESCRIPTION
Updates guides to reflect: lotus/lotus#404.

Also adds a note about `--method` because it's relevant