### PR TITLE
Remove words that presume knowledge

### DIFF
--- a/source/guides/architectures/container.md
+++ b/source/guides/architectures/container.md
@@ -96,7 +96,7 @@ Web assets such as javascripts and stylesheets will be automatically served by t
 Our default application `Web` can be used as a UI interface for our customers.
 At a certain point in our story, we want to manage our users with an admin pane.
 
-We know that the set of features that we're going to introduce, clearly doesn't belong to our main UI (`Web`).
+We know that the set of features that we're going to introduce doesn't belong to our main UI (`Web`).
 On the other hand, it's **too early** for us to implement a microservices architecture, only for the purpose of helping our users reset their password.
 
 Lotus has a solution for our problem: we can generate a new app that lives in the same Ruby process, but it's a separated component.

--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -227,7 +227,7 @@ describe 'List books' do
 end
 ```
 
-The test is simple enough, and obviously fails because the URL `/books` is not currently recognised in our application. We'll create a new controller action to fix that.
+The test is simple enough, and fails because the URL `/books` is not currently recognised in our application. We'll create a new controller action to fix that.
 
 ### Lotus Generators
 
@@ -369,7 +369,7 @@ end
 ### Using Repositories
 
 We can use repositories to read and write entities to our database.
-Of course, in order for that to work, we need to set it up.
+In order for that to work, we need to set it up.
 
 Lotus configurations are stored in env variables.
 This has proven to be a secure and standardized way to handle credentials in deployment environments.
@@ -506,7 +506,7 @@ describe 'List books' do
 end
 ```
 
-We actually create the required records in our test and then assert the correct number of book classes on the page.
+We create the required records in our test and then assert the correct number of book classes on the page.
 When we run this test, we will most likely see an error from our database connection -- remember we only migrated our _development_ database, and not yet our _test_ database.
 Its connection string is defined in `.env.test` and here's how you set it up:
 
@@ -630,7 +630,7 @@ That's enough to make all our tests pass again!
 
 ## Building Forms To Create Records
 
-One of the last steps that remains is to actually make it possible to add new books to the system.
+One of the last remaining steps is to make it possible to add new books to the system.
 The plan is simple: we build a page with a form to enter details.
 
 When the user submits the form, we build a new entity, save it, and redirect the user back to the book listing.
@@ -847,7 +847,7 @@ With our validations in place, we can limit our entity creation and redirection 
 module Web::Controllers::Books
   class Create
     include Web::Action
-    
+
     expose :book
 
     params do


### PR DESCRIPTION
"*Clearly*, *obviously*, *naturally*, and *of course* all presume too much about the reader's knowledge and perspective and often amount to excess verbiage." - [Wikipedia Manual of Style](https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Words_to_watch#Editorializing)

Obviously (:wink:) we're not bound to Wikipedia's Manual of Style, but I think it's a good rule.

I left one 'actually', in the [Displaying Dynamic Data](https://github.com/lotus/lotus.github.io/blob/build/source/guides/getting-started.md#displaying-dynamic-data) of Getting Started, where it says *'If we run our feature test now, we'll see it fails — because our controller action does not __actually__ expose the books to our view'* because it seems useful.