### PR TITLE
Add raw to JSON render

### DIFF
--- a/source/guides/views/mime-types.md
+++ b/source/guides/views/mime-types.md
@@ -63,7 +63,7 @@ module Web::Views::Dashboard
     format :json
 
     def render
-      JSON.generate({foo: 'bar'})
+      raw JSON.generate({foo: 'bar'})
     end
   end
 end


### PR DESCRIPTION
This is one of the only examples of JSON output using lotus. The latest versions of Lotus do HTML safety by default. By adding the `raw` to the method call we give people exploring the docs a more "ready to copy-paste" example.