### PR TITLE
Change masculine pronouns to neutral

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -884,14 +884,14 @@ module Web::Views::Books
 end
 ```
 
-This approach will work nicely because Lotus' form builder is smart enough to introspect the `params` in this action and populate the form fields with values found in the params.
-If the user fills in only one field before submitting, he is presented with his original input, saving him the frustration of typing his original input again.
+This approach will work nicely because Lotus' form builder is smart enough to inspect the `params` in this action and populate the form fields with values found in the params.
+If the user fills in only one field before submitting, they are presented with their original input, saving them the frustration of typing it again.
 
 Run your tests again and see they are all passing again!
 
 ### Displaying Validation Errors
 
-Rather than just shoving the user a form under his nose when something has gone wrong, we should give him a hint of what's expected of him. Let's adapt our form to show a notice about invalid fields.
+Rather than just shoving the user a form under their nose when something has gone wrong, we should give them a hint of what's expected of them. Let's adapt our form to show a notice about invalid fields.
 
 First, we expect a list of errors to be included in the page when `params` contains errors:
 

--- a/source/guides/helpers/escape.md
+++ b/source/guides/helpers/escape.md
@@ -47,7 +47,7 @@ In the profile page we have a link like this:
 ```
 
 A malicious user can edit their profile, by entering javascript code as the website URL.
-When somebody else clicks on that link, he can receive an XSS attack.
+When somebody else clicks on that link, they can receive an XSS attack.
 
 Example:
 


### PR DESCRIPTION
We shouldn't use masculine pronouns by default. Instead we should be more inclusive by using neutral pronouns.